### PR TITLE
Configurable POST URL and hint

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -33,6 +33,8 @@
 
     post '/tinymce_assets' => 'tinymce_assets#create'
 
+  The plugin will relay option "uploadimage\_hint" in the call to `.tinymce()` to the POSTed URL as param `hint`.  You may use this to relay any hints you wish (for example, blog post ID #) to the controller.
+
   This action gets called with a file parameter creatively called `file`, and must respond with JSON, containing the URL to the image.
 
   The JSON has to be returned with a content type of "text/html" to work, which is going to be fixed as soon as possible ([issue #7](https://github.com/PerfectlyNormal/tinymce-rails-imageupload/issues/7)).
@@ -42,6 +44,7 @@
     class TinymceAssetsController < ApplicationController
       def create
         # Take upload from params[:file] and store it somehow...
+        # Optionally also accept params[:hint] and consume if needed
 
         render json: {
           image: {

--- a/vendor/assets/javascripts/tinymce/plugins/uploadimage/dialog.html
+++ b/vendor/assets/javascripts/tinymce/plugins/uploadimage/dialog.html
@@ -43,6 +43,7 @@
         init: function() {
           this.f = document.forms[0];
           this.f.action = tinyMCEPopup.getParam("uploadimage_form_url", "/tinymce_assets");
+          document.getElementById("hint").value = tinyMCEPopup.getParam("uploadimage_hint", "");
           document.getElementById("authenticity_token").value = (window.opener || window.parent).$("meta[name='csrf-token']")[0].content;
         },
 
@@ -59,6 +60,7 @@
     <form method="post" enctype='multipart/form-data' accept-charset="UTF-8" target="hidden_upload" action='#replaceme' name="uploadimageForm">
       <input type="hidden" name="utf8" value="✓">
       <input type="hidden" name="authenticity_token" id="authenticity_token" value="#replaceme">
+      <input type="hidden" name="hint" id="hint" value="#replaceme">
       <iframe id="hidden_upload" name="hidden_upload" src='' onload='uploadDone("hidden_upload")' style='width:0;height:0;border:0px solid #fff'></iframe>
 
       <h1>{#uploadimage_dlg.header}</h1>


### PR DESCRIPTION
Hi

These 2 commits address issues #3 (configurable POST path) and #10 (relay hint to controller).

They are an enhancement and remain backwards compatible if not configured.
