### PR TITLE
Some additional upload options

### DIFF
--- a/app/assets/javascripts/tinymce/plugins/uploadimage/editor_plugin.js.coffee
+++ b/app/assets/javascripts/tinymce/plugins/uploadimage/editor_plugin.js.coffee
@@ -6,8 +6,8 @@
       ed.addCommand 'mceUploadImage', ->
         ed.windowManager.open {
             file:   url + '/dialog.html',
-            width:  320 + parseInt(ed.getLang('uploadimage.delta_width', 0)),
-            height: 180 + parseInt(ed.getLang('uploadimage.delta_height', 0)),
+            width:  350 + parseInt(ed.getLang('uploadimage.delta_width', 0)),
+            height: 220 + parseInt(ed.getLang('uploadimage.delta_height', 0)),
             inline: 1
           }, {
             plugin_url: url

--- a/vendor/assets/javascripts/tinymce/plugins/uploadimage/dialog.html
+++ b/vendor/assets/javascripts/tinymce/plugins/uploadimage/dialog.html
@@ -34,12 +34,12 @@
 
           if(ret.length) {
             var json = JSON.parse(ret);
-            var imgstr = "<span style='";
+            var imgstr = "<span class='uploadimage_item";
             
             if(json["image"]["alignment"])
-              imgstr += "display:block; float: " + json["image"]["alignment"];
+              imgstr += " " + json["image"]["alignment"];
               
-            imgstr += "' class='uploadimage_item'>";
+            imgstr += "'>";
             imgstr += "<img src='" + json["image"]["url"] + "'";
             
             if(json["image"]["height"])
@@ -99,21 +99,33 @@
       <iframe id="hidden_upload" name="hidden_upload" src='' onload='uploadDone("hidden_upload")' style='width:0;height:0;border:0px solid #fff'></iframe>
 
       <h1>{#uploadimage_dlg.header}</h1>
-      <p>{#uploadimage_dlg.input}: <input type="file" name='file' class="file_upload"></p>
-      <p>Alt: <input type="text" name="alt"></p>
-      <p>
-        Image Size:
-        <select id="default_size" name="default_size">
-        </select>
-      </p>
-      <p>
-        Alignment:
-        <select name="alignment">
-          <option value="left">Left</option>
-          <option value="right">Right</option>
-          <option value="center">Center</option>
-        </select>
-      </p>
+      <table border="0" cellpadding="4" cellspacing="0">
+        <tr>
+          <td>{#uploadimage_dlg.input}:</td>
+          <td><input type="file" name='file' class="file_upload"></td>
+        </tr>
+        <tr>
+          <td>Image Alt Value:</td>
+          <td><input type="text" name="alt"></td>
+        </tr>
+        <tr>
+          <td>Image Size:</td>
+          <td>
+            <select id="default_size" name="default_size">
+            </select>
+          </td>
+        </tr>
+        <tr>
+          <td>Alignment:</td>
+          <td>
+            <select name="alignment">
+              <option value="uploadimage_aleft">Left</option>
+              <option value="uploadimage_aright">Right</option>
+              <option value="uploadimage_acenter">Center</option>
+            </select>
+          </td>
+        </tr>
+      </table>
       <div class="mceActionPanel">
         <input type="button" id="insert" name="insert" value="{#uploadimage_dlg.insert}" onclick="UploadImageDialog.insert();"/>
         <input type="button" id="cancel" name="cancel" value="{#uploadimage_dlg.cancel}" onclick="tinyMCEPopup.close();" />


### PR DESCRIPTION
Usually we need some alignment options: Left, Center or Right.
Styles can be passed for the drop-down via (in the form):

<code>
<%= tinymce(uploadimage_hint: @article.id, styles: {med: "Medium (354px)", small: "Small (120x80)"}) %>
</code>

And the Alt for the image.

Need to add the corresponding fields to the image (or asset) model you wanted to use.

Here's a sample controller implementation:

<pre></code>
class Admin::TinymceAssetsController < ApplicationController
  before_filter :require_admin
  
  def create
    if params[:hint] #associate it to the article
      @article = Article.find(params[:hint])
      image = @article.images.new(:asset => params[:file])
      image.alt = params[:alt]
      image.default_size = params[:default_size]
      image.alignment = params[:alignment]
      if image.save
        render json: {
          image: {
            url: image.try(:asset).try(:url, :small)
          }
        }, content_type: "text/html"
      else
        #image could not be saved
      end
    else
      #no association
    end
  end
end
</code></pre>
