### PR TITLE
fix to access iframe document in IE

### DIFF
--- a/vendor/assets/javascripts/tinymce/plugins/uploadimage/dialog.html
+++ b/vendor/assets/javascripts/tinymce/plugins/uploadimage/dialog.html
@@ -48,7 +48,7 @@
           document.getElementById("upload_spinner").className = 'inactive';
           var iframe = document.getElementById("hidden_upload");
           if(iframe.document || iframe.contentDocument) {
-            var doc = iframe.contentDocument ? iframe.contentDocument : iframe.document;
+            var doc = iframe.contentDocument || iframe.contentWindow.document;
             UploadImageDialog.handleResponse(doc.getElementsByTagName("body")[0].innerHTML);
           } else {
             UploadImageDialog.handleError(tinyMCEPopup.getLang("uploadimage_dlg.blank_response", "Didn't get a response from the server"));


### PR DESCRIPTION
You were almost there with your last commit it seems. I made a little tweak to the line that access the iframe document and now it works in IE8 and IE9. This should finally close #29 hopefully!
