### PR TITLE
Use the default TinyMCE4 image icon

### DIFF
--- a/app/assets/javascripts/tinymce/plugins/uploadimage/plugin.js
+++ b/app/assets/javascripts/tinymce/plugins/uploadimage/plugin.js
@@ -13,11 +13,19 @@
           plugin_url: url
         });
       }
-      ed.addButton('uploadimage', {
-        title: ed.translate('Insert an image from your computer'),
-        onclick: showDialog,
-        image: url + '/img/uploadimage.png',
-        stateSelector: 'img[data-mce-uploadimage]'
+      // Add a button that opens a window
+      editor.addButton('uploadimage', {
+        tooltip: ed.translate('Insert an image from your computer'),
+        icon : 'image',
+        onclick: showDialog
+      });
+
+      // Adds a menu item to the tools menu
+      editor.addMenuItem('uploadimage', {
+        text: ed.translate('Insert an image from your computer'),
+        icon : 'image',
+        context: 'insert',
+        onclick: showDialog
       });
     }
   });


### PR DESCRIPTION
This should fix #37 and be in line with TinyMCE4 default icons.

I took the snippet of code from http://justboil.me/ which is a Tinymce 4 uploader made in PHP. It's a creative common so I guess we could take some inspiration there. I will also check the styling to see if we can reuse that as well.
