### PR TITLE
Version number

### DIFF
--- a/lib/tinymce-rails-imageupload/version.rb
+++ b/lib/tinymce-rails-imageupload/version.rb
@@ -1,7 +1,7 @@
 module Tinymce
   module Rails
     module Imageupload
-      VERSION = "4.0.0-alpha.1"
+      VERSION = "4.0.0.alpha.1"
     end
   end
 end


### PR DESCRIPTION
It seems Bundler does not like your dash sign there when running a `bundle install`. Replaced it with a dot and it stopped complaining...
