### PR TITLE
Fixed broken assets compilation.

### DIFF
--- a/lib/tasks/tinymce-uploadimage-assets.rake
+++ b/lib/tasks/tinymce-uploadimage-assets.rake
@@ -9,6 +9,5 @@ Rake::Task[assets_task].enhance do
 
   assets = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__),
     "../../vendor/assets/javascripts/tinymce/plugins/uploadimage")))
-  TinyMCE::Rails::AssetInstaller::ASSETS = assets
-  TinyMCE::Rails::AssetInstaller.new(target, manifest).install
+  TinyMCE::Rails::AssetInstaller.new(assets, target, manifest).install
 end


### PR DESCRIPTION
Currently assets compilation is broken against following versions of rails and rails-tinymce (from the Gemfile.lock):

```
rails (= 3.1.3)
tinymce-rails (3.5.8.3)
tinymce-rails-imageupload (3.5.8.5)  
```

Part of output of rake assets:precompile --trace:

*\* Execute assets:precompile:primary
rake aborted!
wrong number of arguments (2 for 3)
.../vendor/local/ruby/1.9.1/gems/tinymce-rails-3.5.8.3/lib/tinymce/rails/asset_installer.rb:6:in `initialize'
.../vendor/local/ruby/1.9.1/gems/tinymce-rails-imageupload-3.5.8.5/lib/tasks/tinymce-uploadimage-assets.rake:13:in`new'
.../vendor/local/ruby/1.9.1/gems/tinymce-rails-imageupload-3.5.8.5/lib/tasks/tinymce-uploadimage-assets.rake:13:in `block in <top (required)>'

This commit is fixing the problem.
