### PR TITLE
Fix assets task

### DIFF
--- a/lib/tasks/tinymce-uploadimage-assets.rake
+++ b/lib/tasks/tinymce-uploadimage-assets.rake
@@ -9,6 +9,6 @@ Rake::Task[assets_task].enhance do
 
   assets = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__),
     "../../app/assets/javascripts/tinymce/plugins/uploadimage")))
-  TinyMCE::Rails::AssetInstaller::ASSETS = assets
-  TinyMCE::Rails::AssetInstaller.new(target, manifest).install
+
+  TinyMCE::Rails::AssetInstaller.new(assets, target, manifest).install
 end


### PR DESCRIPTION
The arguments needed to initialize `AssetInstaller` has changed since tinymac-rails 3.5.8.3+ and 4.0+.

This pull request makes tinymce-uploadimage compatible with those versions of tinymce-rails.

Please have a look to see if this is an appropriate change.

Thanks! :smile: 
