### PR TITLE
Gem should be added this way for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ The master branch is targetting TinyMCE 4.x.
 
 ### Add the gem to your Gemfile
 
-    gem 'tinymce-rails-imageupload', '~> 4.0.0', :git => 'https://github.com/PerfectlyNormal/tinymce-rails-imageupload.git'
+For now you can easily add the latest beta version
+
+    gem 'tinymce-rails-imageupload', '~> 4.0.0.beta'
 
 ### Set up TinyMCE as you would normally, but in the call to `.tinymce()`, add
 


### PR DESCRIPTION
Can't install gem. Trace:

Fetching gem metadata from https://rubygems.org/........
Fetching additional metadata from https://rubygems.org/..
Resolving dependencies...
Could not find gem 'tinymce-rails-imageupload (~> 4.0.0) ruby' in the gems available on this machine.
