### PR TITLE
Allowing to wrap <img> in <figure>

### DIFF
--- a/app/assets/javascripts/tinymce/plugins/uploadimage/plugin.js
+++ b/app/assets/javascripts/tinymce/plugins/uploadimage/plugin.js
@@ -198,11 +198,11 @@
           var figstr = "<figure";
 
           if (figureClass !== "")
-            figstr += "class='" + figureClass + "'";
+            figstr += " class='" + figureClass + "'";
           figstr += ">" + imgstr;
           figstr += "<figcaption";
           if (figcaptionClass != "")
-            figstr += "class='" + figcaptionClass + "'";
+            figstr += " class='" + figcaptionClass + "'";
           figstr += ">" + alt_text + "</figcaption>";
           figstr += "</figure>";
 


### PR DESCRIPTION
I found it useful to allow wrapping the img in a figure tag and add a figcaption, based on the description you enter in the popup - makes a little better use of it than just putting it in the alt attribute imo.
In the init call, add `uploadimage_figure: true` to create this structure:

``` html
<figure class='figure'>
  <img src='..' alt='whatever'>
  <figcaption class='figcaption'>whatever</figcaption>
</figure>
```

You can also pass other classes with `uploadimage_figure_class` and `uploadimage_figcaption_class`
