### PR TITLE
Generating plugin.js without digest

### DIFF
--- a/lib/tasks/tinymce-uploadimage-assets.rake
+++ b/lib/tasks/tinymce-uploadimage-assets.rake
@@ -2,13 +2,11 @@ assets_task = Rake::Task.task_defined?('assets:precompile:primary') ? 'assets:pr
 
 Rake::Task[assets_task].enhance do
   require "tinymce/rails/asset_installer"
-
   config   = Rails.application.config
   target   = File.join(Rails.public_path, config.assets.prefix)
   manifest = config.assets.manifest
-
   assets = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__),
-    "../../app/assets/javascripts/tinymce/plugins/uploadimage")))
+    "../../app/assets/javascripts/tinymce")))
 
   TinyMCE::Rails::AssetInstaller.new(assets, target, manifest).install
 end


### PR DESCRIPTION
Currently assets:precompile generates plugin.js with digest, but tinymce tries to load plugin.js file. After my modification, assets:precompile task creates public/assets/tinymce/plugins/uploadimage/plugin.js file.