### PR TITLE
Allow gem to work with railties 5.x

### DIFF
--- a/tinymce-rails-imageupload.gemspec
+++ b/tinymce-rails-imageupload.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.license = "MIT"
 
-  s.add_runtime_dependency     "railties",      ">= 3.2", "< 5"
+  s.add_runtime_dependency     "railties",      ">= 3.2", "< 6"
   s.add_runtime_dependency     "tinymce-rails", "~> 4.0"
   s.add_development_dependency "bundler",       "~> 1.0"
   s.add_development_dependency "rails",         ">= 3.1"


### PR DESCRIPTION
The gem works well with Rails 5, let it also be installable with released Rails 5