### PR TITLE
Update tinymce-rails version requirements

### DIFF
--- a/tinymce-rails-imageupload.gemspec
+++ b/tinymce-rails-imageupload.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency     "railties",      ">= 3.1"
-  s.add_runtime_dependency     "tinymce-rails", "~> 3.5.8.1"
+  s.add_runtime_dependency     "tinymce-rails", "~> 3.5", "< 4"
   s.add_development_dependency "bundler",       "~> 1.0"
   s.add_development_dependency "rails",         ">= 3.1"
 end


### PR DESCRIPTION
Update version requirements to install tinymce-rails 3.5.11 which compatible with Rails 5