### PR TITLE
Fix 'uploadDone' function to be able to use json as content type

### DIFF
--- a/app/assets/javascripts/tinymce/plugins/uploadimage/plugin.js
+++ b/app/assets/javascripts/tinymce/plugins/uploadimage/plugin.js
@@ -124,12 +124,17 @@
         if(throbber) {
           throbber.hide();
         }
-
-        var target = iframe.getEl();
-        if(target.document || target.contentDocument) {
-          var doc = target.contentDocument || target.contentWindow.document;
-          handleResponse(doc.getElementsByTagName("body")[0].innerHTML);
-        } else {
+        try {
+          var target = iframe.getEl();
+          if(target.document || target.contentDocument) {
+            var doc = target.contentDocument || target.contentWindow.document;
+            if(String(doc.contentType).includes("html")) {
+              handleResponse(doc.getElementsByTagName("body")[0].innerHTML);
+            } else {
+              handleResponse(doc.getElementsByTagName("pre")[0].innerHTML);
+            }
+          }
+        } catch(e) {
           handleError("Didn't get a response from the server");
         }
       }

--- a/test/dummy/app/controllers/tinymce_assets_controller.rb
+++ b/test/dummy/app/controllers/tinymce_assets_controller.rb
@@ -11,6 +11,6 @@ class TinymceAssetsController < ApplicationController
         height: geometry.height.to_i,
         width:  geometry.width.to_i
       }
-    }, layout: false, content_type: "text/html"
+    }, layout: false, content_type: "application/json"
   end
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -14,7 +14,7 @@
 ActiveRecord::Schema.define(version: 20140220155401) do
 
   create_table "images", force: true do |t|
-    t.string   "alt_text",          default: ""
+    t.string   "alt",               default: ""
     t.string   "hint",              default: ""
     t.string   "file_file_name"
     t.string   "file_content_type"


### PR DESCRIPTION
When responding with some content in the controller, the plugin was getting the HTML content through the "body" tag, but content types such as application/json or text/plain has the "pre" tag instead of "body".

This PR fixes the uploadDone function to use the "body" tag with html content type and "pre" with others, so the response in controller can now be application/json without problems.

#7 