### PR TITLE
Add additional configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ A small demo app demonstrating a working setup for Rails 3.2 ([demo](http://murm
 
 and the rest should happen automatically.
 
+You can also globally have imageupload globally disabled but enabled on specific instances.
+
+~~~yml
+# tinymce.yml
+toolbar: bold italic underline | uploadimage
+plugins:
+  - uploadimage
+uploadimage: false
+~~~
+
+~~~erb
+<%= tinymce uploadimage: true %>
+~~~
+
 ### Set up upload URL and handler
 
 The plugin defaults to POSTing to `/tinymce_assets`. You may modify it by
@@ -86,7 +100,7 @@ Per request `hint` data can be sent to the `create` action through the call to `
 
 Example:
 
-~~~ruby
+~~~erb
 <%= tinymce uploadimage_hint_key: 'post_id', uploadimage_hint: @post.id %>
 ~~~
 
@@ -108,7 +122,7 @@ Params can be sent in a more standard attributes format by setting `uploadimage_
 
 Example:
 
-~~~ruby
+~~~erb
 <%= tinymce uploadimage_model: 'post' %>
 ~~~
 
@@ -137,6 +151,7 @@ Otherwise the inserted HTML is just `<img src="...">`.
 You can set `image_class_list` to an array of `title`, `value` objects to provide uploaders a pre-defined list of CSS classes to apply.
 
 ~~~yml
+# tinymce.yml
 image_class_list:
   - title: 'Center'
     value: 'img-center'

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ A small demo app demonstrating a working setup for Rails 3.2 ([demo](http://murm
 ### Add the gem to your Gemfile
 
     gem 'tinymce-rails-imageupload', '~> 4.0.0.beta'
-    
+
     # or use git
-    
+
     gem 'tinymce-rails-imageupload', github: 'PerfectlyNormal/tinymce-rails-imageupload'
 
 ### Set up TinyMCE as you would normally, but in the call to `.tinymce()`, add
@@ -50,10 +50,6 @@ Routing to your controller must be done manually.
 Set it up using something similar in `routes.rb`:
 
     post '/tinymce_assets' => 'tinymce_assets#create'
-
-The plugin will relay option `uploadimage_hint` in the call to `.tinymce()`
-to the POSTed URL as param `hint`. You may use this to relay any hints
-you wish (for example, blog post ID #) to the controller.
 
 This action gets called with a file parameter creatively called `file`,
 and must respond with JSON, containing the URL to the image.
@@ -76,9 +72,56 @@ Example:
       end
     end
 
+
 If the JSON response contains a `width` and/or `height` key,
 those will be used in the inserted HTML (`<img src="..." width="..." height="...">`),
 but if those are not present, the inserted HTML is just `<img src="...">`.
+
+### Hint param
+
+Per request `hint` data can be sent to the `create` action through the call to `.tinymce()` or `tinymce.yml`. You may use this to relay any hints you wish (for example, blog post ID #) to the controller.
+
+- `uploadimage_hint_key` - override the hint key. Default is `hint`.
+- `uploadimage_hint` - hint value.
+
+Example:
+
+~~~ruby
+<%= tinymce uploadimage_hint_key: 'post_id', uploadimage_hint: @post.id %>
+~~~
+
+Would result in a `params` object that looks like this:
+
+~~~ruby
+{
+  "post_id": 1,
+  "file": ...,
+  // ...
+}
+~~~
+
+### Model attributes
+
+Params can be sent in a more standard attributes format by setting `uploadimage_model`.
+
+- `uploadimage_model` - nest attributes within model namespace.
+
+Example:
+
+~~~ruby
+<%= tinymce uploadimage_model: 'post' %>
+~~~
+
+Would result in a `params` object that looks like this:
+
+~~~ruby
+{
+  "post": {
+    "file": ...,
+    // ...
+  },
+}
+~~~
 
 ### Default class for img tag
 
@@ -86,8 +129,22 @@ By default the plugin doesn't assign any class to the img tag.
 You can set the class(es) by supplying the `uploadimage_default_img_class`
 option in the call to `.tinymce()`.
 
-`class="..."` will only be added to the img tag if a default is specified.
+`class="..."` will only be added to the img tag if a default or custom class is specified.
 Otherwise the inserted HTML is just `<img src="...">`.
+
+### Custom classes
+
+You can set `image_class_list` to an array of `title`, `value` objects to provide uploaders a pre-defined list of CSS classes to apply.
+
+~~~yml
+image_class_list:
+  - title: 'Center'
+    value: 'img-center'
+  - title: 'Left thumbnail'
+    value: 'img-left img-thumbnail'
+  - title: 'Right thumbnail'
+    value: 'img-right img-thumbnail'
+~~~
 
 ## Asset Pipeline
 

--- a/app/assets/javascripts/tinymce/plugins/uploadimage/plugin.js
+++ b/app/assets/javascripts/tinymce/plugins/uploadimage/plugin.js
@@ -11,19 +11,21 @@
           editor = ed;
 
       function showDialog() {
+        var classList = getClassList();
         var body = [
           {type: 'iframe',  url: 'javascript:void(0)'},
           {type: 'textbox', name: 'file', label: ed.translate('Choose an image'), subtype: 'file'},
           {type: 'textbox', name: 'alt',  label: ed.translate('Image description')}
         ];
 
-        if (getClassList().length > 0) {
+        if (classList.length > 0) {
+          selected_class = classList[0].value;
           body = body.concat([
             {
               type: 'listbox',
               name: 'class',
               label: ed.translate('Class'),
-              values: getClassList(),
+              values: classList,
               onSelect: function(e) {
                 selected_class = this.value();
               }

--- a/app/assets/javascripts/tinymce/plugins/uploadimage/plugin.js
+++ b/app/assets/javascripts/tinymce/plugins/uploadimage/plugin.js
@@ -286,20 +286,22 @@
         return values;
       };
 
-      // Add a button that opens a window
-      editor.addButton('uploadimage', {
-        tooltip: ed.translate('Insert an image from your computer'),
-        icon : 'image',
-        onclick: showDialog
-      });
+      if (editor.getParam('uploadimage', true)) {
+        // Add a button that opens a window
+        editor.addButton('uploadimage', {
+          tooltip: ed.translate('Insert an image from your computer'),
+          icon : 'image',
+          onclick: showDialog
+        });
 
-      // Adds a menu item to the tools menu
-      editor.addMenuItem('uploadimage', {
-        text: ed.translate('Insert an image from your computer'),
-        icon : 'image',
-        context: 'insert',
-        onclick: showDialog
-      });
+        // Adds a menu item to the tools menu
+        editor.addMenuItem('uploadimage', {
+          text: ed.translate('Insert an image from your computer'),
+          icon : 'image',
+          context: 'insert',
+          onclick: showDialog
+        });
+      }
     }
   });
 

--- a/app/assets/javascripts/tinymce/plugins/uploadimage/plugin.js
+++ b/app/assets/javascripts/tinymce/plugins/uploadimage/plugin.js
@@ -166,7 +166,7 @@
           var target = iframe.getEl();
           if(target.document || target.contentDocument) {
             var doc = target.contentDocument || target.contentWindow.document;
-            if(String(doc.contentType).includes("html")) {
+            if(String(doc.contentType).indexOf("html") > -1) {
               handleResponse(doc.getElementsByTagName("body")[0].innerHTML);
             } else {
               handleResponse(doc.getElementsByTagName("pre")[0].innerHTML);

--- a/app/assets/javascripts/tinymce/plugins/uploadimage/plugin.js
+++ b/app/assets/javascripts/tinymce/plugins/uploadimage/plugin.js
@@ -60,10 +60,6 @@
           plugin_url: url
         });
 
-        // TinyMCE likes pointless submit handlers
-        win.off('submit');
-        win.on('submit', insertImage);
-
         /* WHY DO YOU HATE <form>, TINYMCE!? */
         iframe = win.find("iframe")[0];
         form = createElement('form', {


### PR DESCRIPTION
New features:

- `uploadimage_hint_key` option to use something other than `hint`.
- `uploadimage_model` to place params in a model namespace. Easier to use strong params.
- `image_class_list` to show a dropdown of CSS classes to add to the image.
- `uploadimage` option to enable/disable without having to modify complex `toolbar` settings.

I can break this into multiple smaller PR if that's preferred.