### PR TITLE
I increased the gem requirements for tinymce

### DIFF
--- a/tinymce-rails-imageupload.gemspec
+++ b/tinymce-rails-imageupload.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.license = "MIT"
 
   s.add_runtime_dependency     "railties",      ">= 3.2", "< 6"
-  s.add_runtime_dependency     "tinymce-rails", "~> 4.0"
+  s.add_runtime_dependency     "tinymce-rails", ">= 5.0"
   s.add_development_dependency "bundler",       "~> 1.0"
   s.add_development_dependency "rails",         ">= 3.1"
 end


### PR DESCRIPTION
The gem connected was old, and this caused issues with rails 5

assets.precompile.primary 